### PR TITLE
Fix warning: Calling <<-EOS.undent is deprecated!

### DIFF
--- a/Formula/swiftenv.rb
+++ b/Formula/swiftenv.rb
@@ -9,13 +9,14 @@ class Swiftenv < Formula
     prefix.install Dir["*"]
   end
 
-  def caveats; <<-EOS.undent
-    To use Homebrew's directories rather than ~/.swiftenv add to your profile:
-      export SWIFTENV_ROOT=#{var}/swiftenv
+  def caveats
+    <<~EOS
+      To use Homebrew's directories rather than ~/.swiftenv add to your profile:
+        export SWIFTENV_ROOT=#{var}/swiftenv
 
-    To enable shims, add the following to your profile:
-      if which swiftenv > /dev/null; then eval "$(swiftenv init -)"; fi
-EOS
+      To enable shims, add the following to your profile:
+        if which swiftenv > /dev/null; then eval "$(swiftenv init -)"; fi
+    EOS
   end
 
   test do


### PR DESCRIPTION
If you are installing `swiftenv` by using the latest homebrew, you are getting a warning:

```bash
Warning: Calling <<-EOS.undent is deprecated!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/kylef/homebrew-formulae/Formula/swiftenv.rb:18:in `caveats'
Please report this to the kylef/formulae tap!
```

This PR fixes that warning.